### PR TITLE
Replace react-native-fetch-blob with rn-fetch-blob

### DIFF
--- a/lib/FileSystem.js
+++ b/lib/FileSystem.js
@@ -9,7 +9,7 @@
 
 import { Platform } from 'react-native';
 import pathLib from 'path';
-import RNFetchBlob from 'react-native-fetch-blob';
+import RNFetchBlob from 'rn-fetch-blob';
 import sha1 from 'crypto-js/sha1';
 import URL from 'url-parse';
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "crypto-js": "^3.1.9-1",
     "path": "^0.12.7",
     "prop-types": "^15.6.0",
-    "react-native-fetch-blob": "0.10.8",
+    "rn-fetch-blob": "^0.10.13",
     "react-native-uuid": "^1.4.9",
     "traverse": "^0.6.6",
     "url-parse": "^1.2.0",


### PR DESCRIPTION
React-native-fetch-blob hasn't been updated in a year and throws Warnings in the latest versions of react-native (usage of deprecated methods)

Switching to rn-fetch-blob fix it.